### PR TITLE
Add 'go.mod' to enable Go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Then, run:
 
 `go get github.com/jsha/minica`
 
+When using Go 1.11 or newer you don't need a $GOPATH and can instead do the
+following:
+
+```
+cd /ANY/PATH
+git clone github.com/jsha/minica
+go build
+## or
+# go install
+```
+
 # Example usage
 
 ```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/jsha/minica


### PR DESCRIPTION
The main advantage of this is that you can now do the following
(assuming Go 1.11 or newer):

    cd /any/path/i/want
    git clone https://github.com/jsha/minica.git
    go build

Citing from the Modules FAQ:

    Should I still add a 'go.mod' file if I do not have any
    dependencies?

    Yes. This supports working outside of GOPATH, helps communicate to
    the ecosystem that you are opting in to modules, and in addition the
    module directive in your go.mod serves as a definitive declaration
    of the identity of your code (which is one reason why import
    comments might eventually be deprecated). Of course, modules are
    purely an opt-in capability in Go 1.11.

https://github.com/golang/go/wiki/Modules