### PR TITLE
Added a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.12.4 as build
+WORKDIR /go/src/minica
+COPY main.go .
+RUN go get && \
+    CGO_ENABLED=0 go build -o /go/bin/minica
+
+FROM scratch as run
+COPY --from=build /go/bin/minica /minica
+ENTRYPOINT ["/minica"]
+CMD ["--help"]


### PR DESCRIPTION
Added a Dockerfile in trying out `minica` in my environment, so I thought I'd share 🙂

This runs the go build process in a Go container, and produces a small (<4MB on my system) image.

To build:
```
docker build --tag=minica:1.0 .
```

To run:
```
docker run --rm -it --name=minica minica:1.0
```

With this minica could be distributed via Docker Hub, eg. as `jsha/minica`.