### PR TITLE
Fix cert expiration time: 2y30d for cert, 100y for CA

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,11 +141,7 @@ func makeRootCert(key crypto.Signer, filename string) (*x509.Certificate, error)
 		},
 		SerialNumber: serial,
 		NotBefore:    time.Now(),
-		// Set the validity period to 2 years and 30 days, to satisfy the iOS and
-		// macOS requirements that all server certificates must have validity
-		// shorter than 825 days:
-		// https://derflounder.wordpress.com/2019/06/06/new-tls-security-requirements-for-ios-13-and-macos-catalina-10-15/
-		NotAfter: time.Now().AddDate(2, 30, 0),
+		NotAfter:     time.Now().AddDate(100, 0, 0),
 
 		SubjectKeyId:          skid,
 		AuthorityKeyId:        skid,
@@ -251,7 +247,11 @@ func sign(iss *issuer, domains []string, ipAddresses []string) (*x509.Certificat
 		},
 		SerialNumber: serial,
 		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(90, 0, 0),
+		// Set the validity period to 2 years and 30 days, to satisfy the iOS and
+		// macOS requirements that all server certificates must have validity
+		// shorter than 825 days:
+		// https://derflounder.wordpress.com/2019/06/06/new-tls-security-requirements-for-ios-13-and-macos-catalina-10-15/
+		NotAfter: time.Now().AddDate(2, 0, 30),
 
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},


### PR DESCRIPTION
fix for aca96c2c
It's the generated leaf certificate that needs a 2years&30days validity (and not 2 years and 30months);
the validity of CA can be longer (restored to 100years as before).