### PR TITLE
Compatibility with paultag version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:buster AS build
+
+RUN apt-get update -y && \
+    apt-get install -y golang
+
+WORKDIR /build
+
+COPY . .
+
+RUN go build
+
+FROM debian:buster
+
+COPY --from=build /build/minica /usr/bin/minica
+
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+      curl ca-certificates openssl
+
+WORKDIR /test
+COPY tests.sh .
+RUN ./tests.sh

--- a/Dockerfile.paultag
+++ b/Dockerfile.paultag
@@ -1,0 +1,9 @@
+FROM debian:buster
+
+RUN apt-get update -y && \
+    apt-get install --no-install-recommends -y \
+      minica curl ca-certificates openssl
+
+WORKDIR /test
+COPY tests.sh .
+RUN ./tests.sh

--- a/README.md
+++ b/README.md
@@ -42,3 +42,10 @@ go build
 # generate and sign an end-entity key and cert, storing them in ./foo.com/
 $ minica --domains foo.com
 ```
+
+For compatibility with another (unaffiliated) tool of the same name, domains
+can also be specified as final arguments:
+
+```
+minica foo.com
+```

--- a/main.go
+++ b/main.go
@@ -313,15 +313,11 @@ will not overwrite existing keys or certificates.
 		flag.PrintDefaults()
 	}
 	flag.Parse()
-	if *domains == "" && *ipAddresses == "" {
+	if flag.NArg() == 0 && *domains == "" && *ipAddresses == "" {
 		flag.Usage()
 		os.Exit(1)
 	}
-	if len(flag.Args()) > 0 {
-		fmt.Printf("Extra arguments: %s (maybe there are spaces in your domain list?)\n", flag.Args())
-		os.Exit(1)
-	}
-	domainSlice := split(*domains)
+	domainSlice := append(split(*domains), (flag.Args())...)
 	domainRe := regexp.MustCompile("^[A-Za-z0-9.*-]+$")
 	for _, d := range domainSlice {
 		if !domainRe.MatchString(d) {

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+echo "world" > hello
+
+minica localhost
+
+set +e
+# FIXME: jsha/minica puts the keypair in a directory, copy those out for compatibility
+# so the same tests work against either version.
+cp localhost/cert.pem localhost.crt
+cp localhost/key.pem localhost.key
+cp minica.pem cacert.crt
+set -e
+
+openssl s_server -cert localhost.crt -key localhost.key -accept 8080 -WWW &
+set +e
+
+curl https://localhost:8080/hello
+if (( $? != 60 )); then
+	exit "Expected request to server with untrusted CA to fail."
+fi
+
+set -e
+cp cacert.crt /usr/share/ca-certificates/
+echo "cacert.crt" >> /etc/ca-certificates.conf
+update-ca-certificates	
+set +e
+
+curl https://localhost:8080/hello
+if (( $? != 0 )); then
+	exit "Expected request to server with trusted CA to succeed."
+fi
+
+# FIXME: -ca-key-size and -key-size are paultag/minica-only right now, but could be ported.
+# set -e
+# minica -ca-key-size 4096 -key-size 4096 127.0.0.1
+# openssl s_server -cert 127.0.0.1.crt -key 127.0.0.1.key -accept 8081 -WWW &
+# set +e
+
+# curl https://127.0.0.1:8081/hello
+# if (( $? != 0 )); then
+# 	exit "Expected request to server with trusted CA to succeed."
+# fi


### PR DESCRIPTION
Okay! As discussed in https://github.com/jsha/minica/issues/48, all key parties (both authors, plus the Debian maintainer) are game to try to unify on a single `minica` implementation. I really appreciate everybody's quick responses and flexibility.

Right now, the situation is a little confusing:

1. Googling for `minica` yields the jsha version.
2. Installing `minica` on Debian (or variants, like Ubuntu) yields the paultag version.
3. Installing `minica` via Homebrew (on macOS) yields the jsha version.

The biggest differences between the tools are in the command-line UI and the default filenames/flags.

In this patch, I've added a single `tests.sh` that exercises the basic functionality (issue a snakeoil CA and cert, trust the snakeoil CA, then use it for a TLS connection), and passes against both versions with the modification to permit domains to be specified as trailing/non-flagged arguments.

If this were to replace the existing Debian version, however, it would still technically be a breaking change for two reasons:

1. The output files for the CA and certificate pairs are different between the two utilities, and cannot be configured with flags currently. What are Debian's rules for a breaking package update like this?
2. One is licensed APL2 and one is licensed MIT, although jsha is the sole author and has offered to dual license as APL2 to address this, if needed. Does this matter for Debian packaging policy?
3. I'm game to port the remaining flags, except for "type." I don't write Go for a job and I doubt I can quickly get the client certificate option from the paultag working as a cleanroom MIT implementation, although if we can work out the licensing, I could probably do it by copy-paste.