### PR TITLE
Fix install instructions for Go 1.17+

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The certificate will have a validity of 2 years and 30 days.
 First, install the [Go tools](https://golang.org/dl/) and set up your `$GOPATH`.
 Then, run:
 
-`go get github.com/jsha/minica`
+`go install github.com/jsha/minica@latest`
 
 When using Go 1.11 or newer you don't need a $GOPATH and can instead do the
 following:


### PR DESCRIPTION
As of Go v1.17+ go get is no longer supported for installing executables. This changes the README to reflect that. For more info see: https://go.dev/doc/go-get-install-deprecation