### PR TITLE
Make ECDSA the default for issuer and end-entity keys

### DIFF
--- a/main.go
+++ b/main.go
@@ -240,7 +240,7 @@ func calculateSKID(pubKey crypto.PublicKey) ([]byte, error) {
 	return skid[:], nil
 }
 
-func sign(iss *issuer, domains []string, ipAddresses []string) (*x509.Certificate, error) {
+func sign(iss *issuer, domains []string, ipAddresses []string, alg x509.PublicKeyAlgorithm) (*x509.Certificate, error) {
 	var cn string
 	if len(domains) > 0 {
 		cn = domains[0]
@@ -254,7 +254,7 @@ func sign(iss *issuer, domains []string, ipAddresses []string) (*x509.Certificat
 	if err != nil && !os.IsExist(err) {
 		return nil, err
 	}
-	key, err := makeKey(fmt.Sprintf("%s/key.pem", cnFolder), x509.RSA)
+	key, err := makeKey(fmt.Sprintf("%s/key.pem", cnFolder), alg)
 	if err != nil {
 		return nil, err
 	}
@@ -314,7 +314,7 @@ func split(s string) (results []string) {
 func main2() error {
 	var caKey = flag.String("ca-key", "minica-key.pem", "Root private key filename, PEM encoded.")
 	var caCert = flag.String("ca-cert", "minica.pem", "Root certificate filename, PEM encoded.")
-	var caAlg = flag.String("ca-alg", "rsa", "Root keypair algorithm: RSA or ECDSA. Only used if generating new.")
+	var caAlg = flag.String("ca-alg", "ecdsa", "Algorithm for any new keypairs: RSA or ECDSA.")
 	var domains = flag.String("domains", "", "Comma separated domain names to include as Server Alternative Names.")
 	var ipAddresses = flag.String("ip-addresses", "", "Comma separated IP addresses to include as Server Alternative Names.")
 	flag.Usage = func() {
@@ -375,6 +375,6 @@ will not overwrite existing keys or certificates.
 	if err != nil {
 		return err
 	}
-	_, err = sign(issuer, domainSlice, ipSlice)
+	_, err = sign(issuer, domainSlice, ipSlice, alg)
 	return err
 }


### PR DESCRIPTION
Make ECDSA the default algorithm for the "-ca-alg" flag, replacing RSA. Also plumb that algorithm through to the end-entity key generation, making that configurable (and also defaulting it to ECDSA). This significantly speeds up minica by default.

```zsh
$ git checkout origin/master
$ go build .
$ time (for i in {1..100}; do ./minica -domains $i.example.com; done)               
22.94s user 1.04s system 100% cpu 23.776 total
```

```zsh
$ git checkout ecdsa-default
$ go build .
$ time (for i in {1..100}; do ./minica -domains $i.example.com; done)
0.76s user 0.56s system 109% cpu 1.204 total
```

Fixes https://github.com/jsha/minica/issues/29